### PR TITLE
prefix hubdock with docker.io/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build the Schematron XSL files from the Schematron source files
-FROM hubdock/php7-apache-saxonhe:12.1 AS builder
+FROM docker.io/hubdock/php7-apache-saxonhe:12.1 AS builder
 
 WORKDIR /build
 COPY build ./
@@ -17,7 +17,7 @@ RUN curl -L https://github.com/elifesciences/eLife-JATS-schematron/raw/${SCHEMAT
 RUN php generate-xsl.php elife-schematron-final.sch elife-final.xsl
 
 # fetch the DTDs and copy the Schematron XSL files into place
-FROM hubdock/php7-apache-saxonhe:12.1
+FROM docker.io/hubdock/php7-apache-saxonhe:12.1
 
 WORKDIR /dtds
 ARG DTDS_VERSION=0.0.9


### PR DESCRIPTION
Tools like `podman` and `buildah`, and probably other tools other than `docker`, recommend and maybe even has defaults where docker.io is not assumed.

On my podman setup I need to answer an interactive prompt as to which registry I want to download an image from. In a non-interactive CI environment I'm not sure what would happen. docker.io is the 3rd fall back in my setup, so if hubdock in on another registry it would pick up from there rather than docker.io.